### PR TITLE
Fix brackets around links in further reading.

### DIFF
--- a/docs/12-further-reading.md
+++ b/docs/12-further-reading.md
@@ -19,9 +19,9 @@ nav_order: 12
   [[link](https://myst-parser.readthedocs.io/en/latest/index.html)]
 - [GitHub Actions](https://docs.github.com/en/actions/)
 - Workflow syntax for GitHub Actions
-  [link](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)]
+  [[link](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)]
 - GitHub Actions for GitHub Pages
-  [link](https://github.com/peaceiris/actions-gh-pages)]
+  [[link](https://github.com/peaceiris/actions-gh-pages)]
 - Carol Willing - Practical Sphinx - PyCon 2018
   [[video](https://www.youtube.com/watch?v=0ROZRNZkPS8)]
 


### PR DESCRIPTION
Added the missing left bracket for these two links in the further reading section:
<img width="329" alt="Screenshot 2023-04-20 at 10 53 45 PM" src="https://user-images.githubusercontent.com/24376333/233543856-1cdaad84-94ad-4c07-b42a-bf767830e833.png">
